### PR TITLE
Fix an out-of-bounds access in building ROP payload

### DIFF
--- a/source/attack_gen.c
+++ b/source/attack_gen.c
@@ -1675,6 +1675,7 @@ int find_gadget_offset(char* search_chars){
           }
           offset++;
         }
+        current_found_i = 0;
       }
     } else {
       current_found_i = 0;


### PR DESCRIPTION
Fix a bug in the first commit:
[L1668](https://github.com/hrosier/ripe64/blob/7bb404ed60d801a3f1b03a9efbeb954a72dfb520/source/attack_gen.c#L1668) `current_found_i++` may grow bigger than `search_chars_count-1`.
In the next loop, [L1658](https://github.com/hrosier/ripe64/blob/7bb404ed60d801a3f1b03a9efbeb954a72dfb520/source/attack_gen.c#L1658) `search_chars[search_chars_count-1-current_found_i]` will trigger an out-of-bounds access.